### PR TITLE
Update Play from 2.3.6 to 2.5.5

### DIFF
--- a/play/Play.nuspec
+++ b/play/Play.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Play</id>
-    <version>2.3.6</version>
+    <version>2.5.5</version>
     <title>Play Framework</title>
     <authors>Play Framework Foundation</authors>
     <owners>kenerwin88 sindux</owners>
@@ -11,9 +11,9 @@
     <iconUrl>https://cdn.rawgit.com/playframework/playframework.com/0926ce54a1ab00ee4bdd2e78f3bb0265f1310a66/public/images/logos/play_icon_full_color.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Play Framework makes it easy to build web applications with Java &amp; Scala. Play is based on a lightweight, stateless, web-friendly architecture.
-    This package installs Play 2.3.6 including Activator 1.2.10.
+    This package installs Play 2.5.5 including Activator 1.3.10.
     If you're upgrading from previous version, you may need to manually remove the previous version from your PATH environment variable.</description>
-    <summary>Play 2.3.6 with Activator 1.2.10</summary>
+    <summary>Play 2.5.5 with Activator 1.3.10</summary>
     <tags>play scala framework</tags>
   </metadata>
 </package>

--- a/play/tools/chocolateyInstall.ps1
+++ b/play/tools/chocolateyInstall.ps1
@@ -1,2 +1,2 @@
-Install-ChocolateyZipPackage 'Play' 'http://downloads.typesafe.com/typesafe-activator/1.2.10/typesafe-activator-1.2.10-minimal.zip' "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-Install-ChocolateyPath "$(Split-Path -parent $MyInvocation.MyCommand.Definition)\activator-1.2.10-minimal"
+Install-ChocolateyZipPackage 'Play' 'https://downloads.typesafe.com/typesafe-activator/1.3.10/typesafe-activator-1.3.10-minimal.zip' "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+Install-ChocolateyPath "$(Split-Path -parent $MyInvocation.MyCommand.Definition)\activator-1.3.10-minimal"


### PR DESCRIPTION
Play 2.5.5 [has been released](https://playframework.com/download) on August, 18. This PR should update play from 2.3.6 to 2.5.5
